### PR TITLE
precise user name for the code rabbit ai

### DIFF
--- a/docs/platforms/gitlab-com.md
+++ b/docs/platforms/gitlab-com.md
@@ -11,7 +11,7 @@ This guide will assist you in effectively integrating CodeRabbit with SaaS GitLa
 
 For the CodeRabbit app to post reviews on merge requests, it needs to interact with the GitLab API, which requires a Personal Access Token. This token can be generated either by using our default CodeRabbit user or by creating a Personal Access Token from one of your existing users.
 
-The CodeRabbit default user is already set up in GitLab SaaS and will be added to your project when you install the CodeRabbit app. During installation, the necessary webhook for the project will also be created.
+The CodeRabbit default user, named "coderabbitai", is already set up in GitLab SaaS and will be added to your project when you install the CodeRabbit app. During installation, the necessary webhook for the project will also be created.
 
 If your organization prefers to use an organization user, you can create a new user in GitLab and generate a Personal Access Token for that user, following [our recommendations](#recommendations).
 


### PR DESCRIPTION
Give the precise user name for the code rabbit ai, to officially confirm it's name.

Later, the documentation mentions that a user can / should create a user himself if he wishes to not use the default user. The recommendation states that the coderabbit logo should be used to easily recognize the new bot.

But this leads to many gitlab users being named "coderabbit-something" with the same logo. Thus confusion exists as to which one is the official default code rabbit gitlab user, and which ones are not.

Documentation should at least mention the official gitlab bot name, as to avoid a user adding a unknown user access to his repositories.