### PR TITLE
Reorganize and expand the Introduction page

### DIFF
--- a/docs/overview/introduction.md
+++ b/docs/overview/introduction.md
@@ -13,8 +13,6 @@ slug: "/"
 
 This page provides a conceptual introduction to CodeRabbit. For a hands-on tutorial, see [Quickstart](/getting-started/quickstart/).
 
-## A responsive and insightful code reviewer
-
 **CodeRabbit** is an AI-powered code reviewer that delivers context-aware feedback on pull requests within minutes, reducing the time and effort needed for manual code reviews. It complements manual reviews by providing a fresh perspective and catching issues that manual reviews often miss, enhancing the overall review quality.
 
 Developers can interact directly with the CodeRabbit bot within their existing Git platform's pull request interface to add context, ask questions, or even have the bot generate code. Over time, CodeRabbit learns from user input and improves its suggestions.

--- a/docs/overview/introduction.md
+++ b/docs/overview/introduction.md
@@ -9,56 +9,86 @@ description:
 slug: "/"
 ---
 
-## What is CodeRabbit?
+# Introduction
 
-> **CodeRabbit** is an AI-powered code reviewer that delivers context-aware feedback on pull requests within minutes, reducing the time and effort needed for manual code reviews. It provides a fresh perspective and catches issues that are often missed, enhancing the overall review quality.
+This page provides a conceptual introduction to CodeRabbit. For a hands-on tutorial, see [Quickstart](/getting-started/quickstart/).
 
-Developers can interact directly with the bot within the code, offering additional context, asking questions, or even having the bot generate code. Over time, **CodeRabbit** learns from user input and improves its suggestions.
+## A repsonsive and insightful code reviewer
 
-:::tip
-See CodeRabbit in action and watch the demo video below to see how it delivers real-time, context-aware feedback on your pull requests in just a few minutes.
-:::
+**CodeRabbit** is an AI-powered code reviewer that delivers context-aware feedback on pull requests within minutes, reducing the time and effort needed for manual code reviews. It complements manual reviews by providing a fresh perspective and catching issues that manual reviews often miss, enhancing the overall review quality.
+
+Developers can interact directly with the CodeRabbit bot within their existing Git platform's pull request interface, in order to add context, ask questions, or even have the bot generate code. Over time, CodeRabbit learns from user input and improves its suggestions.
 
 <div class="video-container">
   <iframe src="https://www.youtube.com/embed/3SyUOSebG7E?si=i0oT9RAnH0PW81lY" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
 </div>
 
-## Integration with GitHub, GitLab and Azure DevOps
+## Core features
 
-> **CodeRabbit** integrates with GitHub, GitLab and Azure DevOps repositories to deliver continuous and incremental reviews for each commit in a pull request (PR) or merge request (MR). Review feedback is automatically sent back to the PR/MR and can be committed directly.
+Core CodeRabbit features include the following:
 
-It works via a webhook, monitoring Pull Request (PR) and Merge Request (MR) events. A comprehensive review is performed when a PR or MR is created, and for
-incremental commits and comments addressed to the bot. The feedback is then sent directly back to the Pull Request or Merge Request.
+- Integrates rapidly with popular Git platforms and workflows.
+- Applies dozens of open-source, industry-standard code analyzers to every commit.
+- Implements code reviews as familiar pull-request comments.
+- Works with contributors through natural-language conversation in comments.
+- Learns and adapts to your team's code style and review preferences.
+- Provides an observability dashboard of code-contribution activity.
+- Practices strong privacy and security, never retaining your code after reviewing it.
+- Free for public repositories, flexible pricing for private code bases.
 
-![CodeRabbit Code Review Flow showing how AI integrates with GitHub and GitLab for continuous pull request feedback.](/img/about/coderabbit-flow.png "CodeRabbit Code Review Flow")
+## Add CodeRabbit to your existing workflow
 
-## Data Privacy and Security
+CodeRabbit shares its reviews as comments attached to pull requests, using the same Git platform that your team already uses. Further commits in the same pull review prompt CodeRabbit to make further reviews, using the earlier reviews as context.
 
-> **CodeRabbit** does not use data collected from code reviews to train or influence its models. All queries to Large Language Models (LLMs) are ephemeral, with zero retention. No data is shared with third parties.
+Each time that it performs a code review, CodeRabbit runs the relevant code changes through [an array of industry-standard code linters, security analyzers, and other tools](/tools/). CodeRabbit synthesizes the output of these tools into its reviews, offering a high-level analysis that can suggest areas for further focus and improvement.
 
-- **Temporary Storage**: Code is temporarily stored in memory during the review process and deleted afterward.
-- **Stored Embeddings**: While the code itself isn’t stored, **CodeRabbit** stores embeddings based on chat conversations and workflow systems (Linear, Jira, GitHub/GitLab issues) to improve future reviews.
-- **Compliance**: All data is kept confidential, isolated by organization, and complies with **SOC2 Type II** and **GDPR** standards.
+Your team can have conversations with CodeRabbit about its reviews by replying to it with follow-up comments on pull requests, asking it questions or making observations about the review using natural language. CodeRabbit continues the conversation appropriately, offering further insights about the code changes, or adjusting its own review style based on feedback.
 
-### Opting Out
+### Teach CodeRabbit your team preferences
 
-You can opt out of data storage at any time without affecting your access to **CodeRabbit**.
-:::warning
-However, opting out may reduce the level of personalized review feedback.
-:::
+As you interact with CodeRabbit through chat, it learns the review preferences of your team, and applies them to all future reviews on a given repository.
 
-## Try CodeRabbit Now
+For example, if CodeRabbit uses a linter to suggest that your pull request use four-space indentations, but your team uses a two-space indentation style, then you can reply to CodeRabbit's pull-request comment to tell it exactly that. CodeRabbit acknowledges your feedback and adjusts all of its subsequent reviews with that repository appropriately.
 
-> Ready to experience **CodeRabbit** in action?
+For a video introduction to this feature, see [CodeRabbit Learnings](https://www.youtube.com/watch?v=Yu0cmmOYA-U).
 
-:::tip
-For open source projects CodeRabbit Pro is **_FREE_**, forever.
+If you need to fine-tune CodeRabbit's behavior beyond this, then you can [add a CodeRabbit-specific configuration file](getting-started/configure-coderabbit) to your repository, or use the CodeRabbit web UI to set further preferences.
 
-- No credit card required
-- Unlimited public repositories
+No matter how you tune and customize CodeRabbit, its default settings make it useful out of the box, able to meaningfully review pull requests within minutes of its introduction to a repository.
 
-:::
+### Integrate CodeRabbit with your Git platform
 
-<div style={{textAlign: 'left', marginTop: '20px'}}>
-  <a href="https://app.coderabbit.ai/login" className="button button--primary button--lg">Start reviewing PR Now</a>
-</div>
+CodeRabbit integrates in a just a few clicks with many popular Git platforms:
+
+- GitHub, including GitHub Enterprise Server
+- GitLab, including self-managed GitLab
+- Azure DevOps
+- Bitbucket Cloud
+
+In addition, CodeRabbit can integrate with a number of popular workflow systems:
+
+- Jira
+- Linear
+- CircleCI
+
+## Data privacy and security
+
+CodeRabbit does not use data collected from code reviews to train or influence its models. All queries to large language models (LLMs) are ephemeral, with zero retention. No data is shared with third parties.
+
+- **Temporary Storage**: CodeRabbit temporarily stores your code in memory during the review process, and deletes it afterward.
+- **Stored Embeddings**: While CodeRabbit doesn't store your code, it does store embeddings based on chat conversations and workflow systems (Linear, Jira, GitHub/GitLab issues) to improve future reviews.
+- **Compliance**: All data is kept confidential, isolated by organization, and complies with SOC2 Type II and GDPR standards.
+
+You can opt out of data storage at any time without affecting your access to CodeRabbit. Opting out might reduce the level of personalized review feedback that CodeRabbit can provide you.
+
+## Flexible pricing, free for public use
+
+Public repositories can use the Pro tier of CodeRabbit at no charge, including all of the code-review features described on this page. Rate limits might apply.
+
+For private repositories, a number of pricing tiers are available. These range from a Free tier that offers unlimited code-change summaries, to an Enterprise tier with access to advanced features and SLA support. For more information, see [Pricing](https://www.coderabbit.ai/pricing).
+
+## What's next
+
+- [Quickstart](/getting-started/quickstart/) lets you experience your first CodeRabbit code review first-hand.
+
+- [Why CodeRabbit?](/overview/why-coderabbit) dives further into the philosophies and technologies that drive CodeRabbit.

--- a/docs/overview/introduction.md
+++ b/docs/overview/introduction.md
@@ -36,7 +36,7 @@ Core CodeRabbit features include the following:
 - Practices strong privacy and security, with no retention of analyzed code.
 - Offers free use for public repositories, and flexible pricing for private codebases.
 
-## Add CodeRabbit to your existing workflow
+## Seamless workflow integration
 
 CodeRabbit shares its reviews as comments attached to pull requests, using the same Git platform that your team already uses. Further commits in the same pull review prompt CodeRabbit to make further reviews, using the earlier reviews as context.
 
@@ -44,7 +44,7 @@ Each time that it performs a code review, CodeRabbit runs the relevant code chan
 
 Your team can have conversations with CodeRabbit about its reviews by replying to it with follow-up comments on pull requests, asking it questions or making observations about the review using natural language. CodeRabbit continues the conversation appropriately, offering further insights about the code changes, or adjusting its own review style based on feedback.
 
-### Teach CodeRabbit your team preferences
+### Customizable review preferences
 
 As you interact with CodeRabbit through chat, it learns the review preferences of your team, and applies them to all future reviews on a given repository.
 
@@ -56,7 +56,7 @@ If you need to fine-tune CodeRabbit's behavior beyond this, then you can [add a 
 
 No matter how you tune and customize CodeRabbit, its default settings make it useful out of the box, able to meaningfully review pull requests within minutes of its introduction to a repository.
 
-### Integrate CodeRabbit with your Git platform
+### Platform integration options
 
 CodeRabbit integrates in just a few clicks with many popular Git platforms:
 

--- a/docs/overview/introduction.md
+++ b/docs/overview/introduction.md
@@ -34,7 +34,7 @@ Core CodeRabbit features include the following:
 - Learns and adapts to your team's code style and review preferences.
 - Provides an observability dashboard of code-contribution activity.
 - Practices strong privacy and security, with no retention of analyzed code.
-- Free for public repositories, flexible pricing for private code bases.
+- Offers free use for public repositories, and flexible pricing for private codebases.
 
 ## Add CodeRabbit to your existing workflow
 
@@ -52,7 +52,7 @@ For example, if CodeRabbit uses a linter to suggest that your pull request use f
 
 For a video introduction to this feature, see [CodeRabbit Learnings](https://www.youtube.com/watch?v=Yu0cmmOYA-U).
 
-If you need to fine-tune CodeRabbit's behavior beyond this, then you can [add a CodeRabbit-specific configuration file](/getting-started/configure-coderabbit) to your repository, or use the CodeRabbit web UI to set further preferences.
+If you need to fine-tune CodeRabbit's behavior beyond this, then you can [add a CodeRabbit-specific configuration file](/getting-started/configure-coderabbit) to your repository, or use the CodeRabbit web UI to set further preferences. This file can include [path-based instructions](/guides/review-instructions) for how CodeRabbit should review different files within your codebase.
 
 No matter how you tune and customize CodeRabbit, its default settings make it useful out of the box, able to meaningfully review pull requests within minutes of its introduction to a repository.
 

--- a/docs/overview/introduction.md
+++ b/docs/overview/introduction.md
@@ -13,11 +13,11 @@ slug: "/"
 
 This page provides a conceptual introduction to CodeRabbit. For a hands-on tutorial, see [Quickstart](/getting-started/quickstart/).
 
-## A repsonsive and insightful code reviewer
+## A responsive and insightful code reviewer
 
 **CodeRabbit** is an AI-powered code reviewer that delivers context-aware feedback on pull requests within minutes, reducing the time and effort needed for manual code reviews. It complements manual reviews by providing a fresh perspective and catching issues that manual reviews often miss, enhancing the overall review quality.
 
-Developers can interact directly with the CodeRabbit bot within their existing Git platform's pull request interface, in order to add context, ask questions, or even have the bot generate code. Over time, CodeRabbit learns from user input and improves its suggestions.
+Developers can interact directly with the CodeRabbit bot within their existing Git platform's pull request interface to add context, ask questions, or even have the bot generate code. Over time, CodeRabbit learns from user input and improves its suggestions.
 
 <div class="video-container">
   <iframe src="https://www.youtube.com/embed/3SyUOSebG7E?si=i0oT9RAnH0PW81lY" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
@@ -33,7 +33,7 @@ Core CodeRabbit features include the following:
 - Works with contributors through natural-language conversation in comments.
 - Learns and adapts to your team's code style and review preferences.
 - Provides an observability dashboard of code-contribution activity.
-- Practices strong privacy and security, never retaining your code after reviewing it.
+- Practices strong privacy and security, with no retention of analyzed code.
 - Free for public repositories, flexible pricing for private code bases.
 
 ## Add CodeRabbit to your existing workflow
@@ -52,13 +52,13 @@ For example, if CodeRabbit uses a linter to suggest that your pull request use f
 
 For a video introduction to this feature, see [CodeRabbit Learnings](https://www.youtube.com/watch?v=Yu0cmmOYA-U).
 
-If you need to fine-tune CodeRabbit's behavior beyond this, then you can [add a CodeRabbit-specific configuration file](getting-started/configure-coderabbit) to your repository, or use the CodeRabbit web UI to set further preferences.
+If you need to fine-tune CodeRabbit's behavior beyond this, then you can [add a CodeRabbit-specific configuration file](/getting-started/configure-coderabbit) to your repository, or use the CodeRabbit web UI to set further preferences.
 
 No matter how you tune and customize CodeRabbit, its default settings make it useful out of the box, able to meaningfully review pull requests within minutes of its introduction to a repository.
 
 ### Integrate CodeRabbit with your Git platform
 
-CodeRabbit integrates in a just a few clicks with many popular Git platforms:
+CodeRabbit integrates in just a few clicks with many popular Git platforms:
 
 - GitHub, including GitHub Enterprise Server
 - GitLab, including self-managed GitLab


### PR DESCRIPTION
This rewrite puts more emphasis on the ease of using CodeRabbit with quick integration and friendly chat, as well as tools and learnings. This change de-emphasizes how CodeRabbit works, removing an operational diagram and information about its use of web hooks. That material is better suited for deep-dive docs, or blog posts and such.

Staging: https://overview.coderabbit-docs.pages.dev