### PR TITLE
Add the review-instructions guide back to the ToC.

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -92,7 +92,7 @@ Email field and click Update to save your changes.
 ### Usage and Configuration
 
 - **Language Settings**: Configure review language in repository settings
-- **Review Rules**: Customize via [Review Instructions](/guides/review-instructions)
+- **Review Rules**: Customize via [review instructions](/guides/review-instructions)
 - **Branch Selection**: Default branch reviews enabled by default (configurable)
 
 ### Access & Permissions
@@ -108,7 +108,7 @@ Interact with CodeRabbit by:
 1. Replying directly to CodeRabbit comments
 2. Tagging `@coderabbitai` in PR discussions
 3. Adding review comments for specific lines
-4. Customize via [Review Instructions](/guides/review-instructions)
+4. Customize via [review instructions](/guides/review-instructions)
 
 :::tip Collaboration Mode
 When team members are active in PRs, use `@coderabbitai` to engage the bot.

--- a/docs/guides/linked-issues.md
+++ b/docs/guides/linked-issues.md
@@ -168,6 +168,6 @@ Only the issue title and description are considered in the assessment. Comments 
 
 ## Related Resources
 
-- [Review Instructions](./review-instructions.md)
+- [Add review Instructions](/guides/review-instructions)
 - [Issue Chat](./issue-chat.md)
 - [Issue Creation](./issue-creation.md)

--- a/docs/guides/linked-issues.md
+++ b/docs/guides/linked-issues.md
@@ -168,6 +168,6 @@ Only the issue title and description are considered in the assessment. Comments 
 
 ## Related Resources
 
-- [Add review Instructions](/guides/review-instructions)
+- [Add review instructions](/guides/review-instructions)
 - [Issue Chat](./issue-chat.md)
 - [Issue Creation](./issue-creation.md)

--- a/docs/guides/review-instructions.md
+++ b/docs/guides/review-instructions.md
@@ -1,11 +1,9 @@
 ---
-title: Review Instructions
-sidebar_label: Review Instructions
+title: Add review instructions
 description:
   CodeRabbit offers various customization options to tailor the reviews to your
   specific requirements. Customizations can be made using one of the below
   options.
-sidebar_position: 2
 ---
 
 The guide explains how to add custom review instructions for the entire project.

--- a/docs/platforms/github-com.md
+++ b/docs/platforms/github-com.md
@@ -109,7 +109,7 @@ CodeRabbit generates detailed statistics and test plans for each pull request.
 
 ![Test Plan by CodeRabbit](/img/integrations/test-plan.png)
 
-> CodeRabbit also allows you to configure **custom review instructions** based on your organization's needs, in case you want it to follow specific guidelines beyond the standard review, to learn more on [adding custom review instructions](https://docs.coderabbit.ai/guides/review-instructions/)
+> CodeRabbit also allows you to configure **custom review instructions** based on your organization's needs, in case you want it to follow specific guidelines beyond the standard review, to learn more on [adding custom review instructions](/guides/review-instructions/)
 
 Whether you manage a popular repository or are working on a smaller project, whether it's hosted on **GitLab, GitHub, or self-hosted GitHub or GitLab**, CodeRabbit can help streamline your development process. This AI Code Review assistant is designed to save you time by automating code reviews and offering insightful feedback.
 

--- a/docs/platforms/github-com.md
+++ b/docs/platforms/github-com.md
@@ -109,7 +109,7 @@ CodeRabbit generates detailed statistics and test plans for each pull request.
 
 ![Test Plan by CodeRabbit](/img/integrations/test-plan.png)
 
-> CodeRabbit also allows you to configure **custom review instructions** based on your organization's needs, in case you want it to follow specific guidelines beyond the standard review, to learn more on [adding custom review instructions](/guides/review-instructions/)
+> CodeRabbit also allows you to configure **custom review instructions** based on your organization's needs, in case you want it to follow specific guidelines beyond the standard review, to learn more on [adding custom review instructions](/guides/review-instructions)
 
 Whether you manage a popular repository or are working on a smaller project, whether it's hosted on **GitLab, GitHub, or self-hosted GitHub or GitLab**, CodeRabbit can help streamline your development process. This AI Code Review assistant is designed to save you time by automating code reviews and offering insightful feedback.
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -75,6 +75,7 @@ const sidebars: SidebarsConfig = {
 			items: [
 				"getting-started/configure-coderabbit",
 				"integrations/knowledge-base",
+				"guides/review-instructions",
 				"tools/tools",
 			],
 		},


### PR DESCRIPTION
Repair a regression introduced with #301.

Normalize a few links and page titles regarding the review-instructions page.

Staged: https://toc-fix.coderabbit-docs.pages.dev/