### PR TITLE
Add documentation for the VSCode extension

### DIFF
--- a/docs/guides/about-vscode.md
+++ b/docs/guides/about-vscode.md
@@ -1,0 +1,30 @@
+---
+title: Overview
+description: How to review your code with the VSCode extension.
+---
+
+This page is about the CodeRabbit VSCode extension. For a broader overview of CodeRabbit, see [Introduction](/overview/introduction).
+
+## About the VSCode extension
+
+The CodeRabbit VSCode extension lets you apply a limited subset of CodeRabbit’s code-review features to your local development environment, directly from the VSCode IDE.
+
+## Features
+
+The extension includes the following features:
+
+- Automatic reviews of local Git commmits
+
+- Manually requested reviews of local code changes
+
+## Price and limitations
+
+This extension is free to install and use, and works with any tier of CodeRabbit account. You can use the extension on its own, or you can use it to complement your local development on a repository whose remote has CodeRabbit installed.
+
+Rate limits apply to the numnber of local reviews that you can request per hour.
+
+## What's next
+
+- [Install the VSCode extension](/guides/install-extension)
+
+- [Use the VSCode extension](/guides/use-extension)

--- a/docs/guides/about-vscode.md
+++ b/docs/guides/about-vscode.md
@@ -5,7 +5,7 @@ slug: /code-editors
 sidebar_label: Overview
 ---
 
-This page is about the CodeRabbit VSCode extension. For a broader overview of CodeRabbit, see [Introduction](/overview/introduction).
+This page is about the CodeRabbit VSCode extension. For a broader overview of CodeRabbit, see [Introduction](/).
 
 ## About the VSCode extension
 

--- a/docs/guides/about-vscode.md
+++ b/docs/guides/about-vscode.md
@@ -21,6 +21,7 @@ The extension includes the following features:
 
 - Automatic code reviews on every local Git commit
 - Manually requested reviews of local code changes
+- Full compatibility with text editors derived from VSCode, including Cursor and Windsurf
 
 ## Price and limitations
 

--- a/docs/guides/about-vscode.md
+++ b/docs/guides/about-vscode.md
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: VSCode extension overview
 description: How to review your code with the VSCode extension.
 ---
 
@@ -9,19 +9,23 @@ This page is about the CodeRabbit VSCode extension. For a broader overview of Co
 
 The CodeRabbit VSCode extension lets you apply a limited subset of CodeRabbit’s code-review features to your local development environment, directly from the VSCode IDE.
 
+The extension is intended to let you use the power of CodeRabbit to rapidly tune and tidy your code changes locally, before you publish your changes to your team's remote repository and start a more thorough code review.
+
 ## Features
 
 The extension includes the following features:
 
 - Automatic reviews of local Git commmits
 
-- Manually requested reviews of local code changes
+- Manually requested reviews of local code changes, either committed or uncommited
 
 ## Price and limitations
 
-This extension is free to install and use, and works with any tier of CodeRabbit account. You can use the extension on its own, or you can use it to complement your local development on a repository whose remote has CodeRabbit installed.
+This extension is free to install and use, and works with any tier of CodeRabbit account. Rate limits apply to the numnber of local reviews that you can request per hour.
 
-Rate limits apply to the numnber of local reviews that you can request per hour.
+You can use the extension on its own, or you can use it to complement your local development on a repository whose remote has CodeRabbit installed.
+
+As such, the extension makes only the most basic CodeRabbit review features available, with default settings applied. Advanced CodeRabbit features, such as interactive chat and project learnings, aren't available through the VSCode extension. These features are available only by [integrating CodeRabbit on your remote repository](/platforms), and then allowing CodeRabbit to review pull requests.
 
 ## What's next
 

--- a/docs/guides/about-vscode.md
+++ b/docs/guides/about-vscode.md
@@ -9,7 +9,7 @@ This page is about the CodeRabbit VSCode extension. For a broader overview of Co
 
 ## About the VSCode extension
 
-The CodeRabbit VSCode extension lets you apply a limited subset of CodeRabbit’s code-review features to your local development environment, directly from the VSCode IDE.
+The CodeRabbit VSCode extension lets you apply a limited subset of CodeRabbit’s code-review features to your local development environment, directly from the VSCode IDE. It also works with other text editors that are able to install and use VSCode extensions, such as Cursor and Windsurf.
 
 You can use the extension on its own, or you can use it to complement your local development on a repository whose remote has CodeRabbit installed.
 

--- a/docs/guides/about-vscode.md
+++ b/docs/guides/about-vscode.md
@@ -1,6 +1,8 @@
 ---
-title: VSCode extension overview
+title: Review local changes
 description: How to review your code with the VSCode extension.
+slug: /code-editors
+sidebar_label: Overview
 ---
 
 This page is about the CodeRabbit VSCode extension. For a broader overview of CodeRabbit, see [Introduction](/overview/introduction).
@@ -9,26 +11,24 @@ This page is about the CodeRabbit VSCode extension. For a broader overview of Co
 
 The CodeRabbit VSCode extension lets you apply a limited subset of CodeRabbit’s code-review features to your local development environment, directly from the VSCode IDE.
 
+You can use the extension on its own, or you can use it to complement your local development on a repository whose remote has CodeRabbit installed.
+
 The extension is intended to let you use the power of CodeRabbit to rapidly tune and tidy your code changes locally, before you publish your changes to your team's remote repository and start a more thorough code review.
 
 ## Features
 
 The extension includes the following features:
 
-- Automatic reviews of local Git commmits
-
-- Manually requested reviews of local code changes, either committed or uncommited
+- Automatic code reviews on every local Git commit
+- Manually requested reviews of local code changes
 
 ## Price and limitations
 
-This extension is free to install and use, and works with any tier of CodeRabbit account. Rate limits apply to the numnber of local reviews that you can request per hour.
+This extension is free to install and use, and works with any tier of CodeRabbit account. Rate limits apply to the number of local reviews that you can request per hour.
 
-You can use the extension on its own, or you can use it to complement your local development on a repository whose remote has CodeRabbit installed.
-
-As such, the extension makes only the most basic CodeRabbit review features available, with default settings applied. Advanced CodeRabbit features, such as interactive chat and project learnings, aren't available through the VSCode extension. These features are available only by [integrating CodeRabbit on your remote repository](/platforms), and then allowing CodeRabbit to review pull requests.
+The extension makes only basic CodeRabbit review features available, with default settings applied. Advanced CodeRabbit features, such as interactive chat and project learnings, aren't available through the VSCode extension. These features are available only by [integrating CodeRabbit on your remote repository](/platforms), and then allowing CodeRabbit to review pull requests.
 
 ## What's next
 
-- [Install the VSCode extension](/guides/install-extension)
-
-- [Use the VSCode extension](/guides/use-extension)
+- [Install the VSCode extension](/guides/install-vscode)
+- [Use the VSCode extension](/guides/use-vscode)

--- a/docs/guides/install-vscode.md
+++ b/docs/guides/install-vscode.md
@@ -4,7 +4,7 @@ description: How to install the CodeRabbit VSCode extension
 ---
 
 This page is about installing the CodeRabbit VSCode extension. For more information about the extension, see
-[Overview](/guides/about-vscode).
+[Review local changes](/code-editors).
 
 ## Before you begin
 
@@ -36,7 +36,7 @@ To install the CodeRabbit VSCode extension, follow these steps:
 
 1. In your web browser, log into your CodeRabbit account.
 
-This connects your CodeRabbit account with the CodeRabit VSCode extension.
+This connects your CodeRabbit account with the CodeRabbit VSCode extension.
 
 ## What's next
 

--- a/docs/guides/install-vscode.md
+++ b/docs/guides/install-vscode.md
@@ -6,6 +6,10 @@ description: How to install the CodeRabbit VSCode extension
 This page is about installing the CodeRabbit VSCode extension. For more information about the extension, see
 [Review local changes](/code-editors).
 
+:::note
+The instructions on this page are specific to using the extension with VSCode. If you are instead using a VSCode-compatible editor such as Cursor or Windsurf, then the steps that you need to follow are similar, but might require some adaptation.
+:::
+
 ## Before you begin
 
 Before you can use the CodeRabbit VSCode extension, you need a CodeRabbit account.
@@ -16,7 +20,7 @@ If you don't already have an account, you can create one by visiting [the CodeRa
 
 To install the CodeRabbit VSCode extension, follow these steps:
 
-1. Visit [the extension's page on the Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=CodeRabbit.coderabbit-vscode).
+1. Visit [the extension's page on the Visual Studio Marketplace](https://coderabbit.link/vscode-docs).
 
 1. Click **Install**.
 

--- a/docs/guides/install-vscode.md
+++ b/docs/guides/install-vscode.md
@@ -1,0 +1,43 @@
+---
+title: Install the VSCode extension
+description: How to install the CodeRabbit VSCode extension
+---
+
+This page is about installing the CodeRabbit VSCode extension. For more information about the extension, see
+[Overview](/guides/about-vscode).
+
+## Before you begin
+
+Before you can use the CodeRabbit VSCode extension, you need a CodeRabbit account.
+
+If you don't already have an account, you can create one by visiting [the CodeRabbit login page](https://app.coderabbit.ai/login).
+
+## Install the extension
+
+To install the CodeRabbit VSCode extension, follow these steps:
+
+1. Visit [the extension's page on the Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=CodeRabbit.coderabbit-vscode).
+
+1. Click **Install**.
+
+1. If your browser asks you for permission to open VSCode, then click **Allow** or its equivalent control.
+
+1. A summary of the CodeRabbit VSCode extension appears in your VSCode window. If you would like VSCode to automatically check for and apply future updates to the extension, then keep the **Auto Update** checkbox selected.
+
+1. In VSCode, click **Install**.
+
+1. A **Log in to CodeRabbit to get started** dialog appears. Click **Login**. If the dialog gets dismissed or times out first, then you can follow these alternate steps:
+
+   1. Click the CodeRabbit icon in the VSCode activity bar.
+
+   1. Click the **Use CodeRabbit for Free** button.
+
+1. Grant VSCode permission to open your browser, if asked.
+
+1. In your web browser, log into your CodeRabbit account.
+
+This connects your CodeRabbit account with the CodeRabit VSCode extension.
+
+## What's next
+
+- [Use the VSCode extension](/guides/use-vscode)

--- a/docs/guides/uninstall-vscode.md
+++ b/docs/guides/uninstall-vscode.md
@@ -1,10 +1,10 @@
 ---
 title: Uninstall the VSCode extension
-description: How to uinstall the CodeRabbit VSCode extension
+description: How to uninstall the CodeRabbit VSCode extension
 ---
 
 This page is about uninstalling the CodeRabbit VSCode extension. For more information about the extension, see
-[Overview](/guides/about-vscode).
+[Review local changes](/code-editors).
 
 ## Uninstall the extension
 

--- a/docs/guides/uninstall-vscode.md
+++ b/docs/guides/uninstall-vscode.md
@@ -6,6 +6,10 @@ description: How to uninstall the CodeRabbit VSCode extension
 This page is about uninstalling the CodeRabbit VSCode extension. For more information about the extension, see
 [Review local changes](/code-editors).
 
+:::note
+The instructions on this page are specific to using the extension with VSCode. If you are instead using a VSCode-compatible editor such as Cursor or Windsurf, then the steps that you need to follow are similar, but might require some adaptation.
+:::
+
 ## Uninstall the extension
 
 To uninstall the VSCode extension, follow these steps:

--- a/docs/guides/uninstall-vscode.md
+++ b/docs/guides/uninstall-vscode.md
@@ -1,0 +1,21 @@
+---
+title: Uninstall the VSCode extension
+description: How to uinstall the CodeRabbit VSCode extension
+---
+
+This page is about uninstalling the CodeRabbit VSCode extension. For more information about the extension, see
+[Overview](/guides/about-vscode).
+
+## Uninstall the extension
+
+To uninstall the VSCode extension, follow these steps:
+
+1. In the VSCode activity bar, click the CodeRabbit icon.
+
+1. In the CodeRabbit sidebar, click the door-shaped **Logout** icon.
+
+1. In the VSCode activity bar, click the **Extensions** icon.
+
+1. In the Extensions sidebar, click the gear-shaped **Manage** icon next to CodeRabbit in the list of installed extensions.
+
+1. Select **Uninstall**.

--- a/docs/guides/use-vscode.md
+++ b/docs/guides/use-vscode.md
@@ -3,8 +3,10 @@ title: Use the VSCode extension
 description: How to review your code with the VSCode extension.
 ---
 
-This page is about using the CodeRabbit VSCode extension. For more information about the extension, see
-[Overview](/guides/about-vscode). To learn how to install the extension, see [Install the VSCode extension](/guides/install-vscode).
+This page is about performing local code reviews using the CodeRabbit VSCode extension. For more information about the extension, see
+[Review local changes](/code-editors). To learn how to install the extension, see [Install the VSCode extension](/guides/install-vscode).
+
+The CodeRabbit VSCode extension works by comparing changes in your current, checked-out Git branch against another branch in your local repository. You can use the extension to automatically perform full-branch changes after every commit, or make different kinds of comparisons by manually requesting a review.
 
 ## Automatically review local commits
 
@@ -18,6 +20,8 @@ To perform an automatic review, follow these steps:
 
 1. Wait for the review to complete. This might take several minutes. To cancel a review in progress, click **Stop the review**.
 
+After the review completes, you can browse and respond to review comments as described in [Work with code reviews](#work-with-code-reviews).
+
 For more options and control of code reviews performed using the CodeRabbit VSCode extension, you can manually request a review, as detailed in the following section.
 
 ## Manually request code reviews
@@ -26,10 +30,10 @@ To manually review changes in a local Git branch using the CodeRabbit VSCode ext
 
 1.  Click the CodeRabbit icon in the VSCode activity bar. The CodeRabbit sidebar appears.
 
-1.  Refer to **Branch** in the CodeRabbit sidebar. If you want to compare your code changes
-    to a branch other than the default that appears, then follow these steps:
+1.  If you want to compare your code changes
+    to a branch other than its base branch, then follow these steps:
 
-        1. Click the name of the base branch, which is `main` by default. A **Select a base branch** dialog appears, listing other branches in your local Git repository.
+        1. In the sidebar, under **Branch**, click the name of the base branch. A **Select a base branch** dialog appears, listing other branches in your local Git repository.
 
         1. Select the name of a base branch to compare against.
 
@@ -38,16 +42,50 @@ To manually review changes in a local Git branch using the CodeRabbit VSCode ext
     - To review all changes between the base branch and your current branch, including
       both committed and uncommitted changes, select **Review all changes**. This is the default selection.
 
-    - To limit the review to only changes on your branch that you have committed, select **Review committed changes**. This includes both pushed and not-pushed commits on the current branch.
+    - To limit the review to only changes on your branch that you have committed, select **Review committed changes**. This includes commits that you have pushed to your remote repository, if any, as well as any local commits.
 
-    - To limit the review to only uncommitted changes on your branch, select **Review all changes**.
+    - To limit the review to only uncommitted changes on your branch, select **Review uncommitted changes**.
 
-1.  Refer to the list of **Files to review** in the sidebar. This list represents all of the files that the selected review style includes. To change this list of files, repeat the previous step to choose a different review style, or use Git features like `git stash` to remove changes to files.
+1.  Refer to the list of **Files to review** in the sidebar. This list represents all of the files that the selected review action includes. To change this list of files, repeat the previous step to choose a different review action, or use Git features like `git stash` to selectively remove changes.
 
 1.  To perform the review, click the button part of the menu. The CodeRabbit sidebar displays a **Review** section with the review's progress.
 
 1.  Wait for the review to complete. This might take several minutes. To cancel a review in progress, click **Stop the review**.
 
+After the review completes, you can browse and respond to review comments as described in the following section.
+
+## Work with code reviews
+
+The CodeRabbit VSCode extension presents code reviews as a series of actionable comments, connected to specific files and lines. It gives you tools to apply its suggestions quickly, when possible.
+
+### Browse comments
+
+After the extension finishes its review, it adds any comments to the CodeRabbit sidebar under the **Files** heading in the **Reviews** section.
+
+Each item in **Files** is a comment referring to one or more lines in that file. Click the comment to see a detailed, inline comment in the editor, attached to the appropriate file and lines.
+
+You can react to these comments however you want: you can apply their advice literally, or let them guide you to find alternate solutions, or ignore them entirely. CodeRabbit comments are metadata stored with VSCode, and are not part of your files. The presence of comments doesn't block your use of version control.
+
+### Apply suggested changes
+
+Whenever possible, the CodeRabbit VSCode extension attaches discrete change suggestion to comments in the form of code diffs. For example, if it detects a typo in a new function name, the extension might attach a diff with a suggested correction.
+
+If you agree with CodeRabbit about the suggested fix and want to apply to exactly as it proposes, click the checkmark-shaped **Apply suggested change** icon in the inline comment. The extension makes the change for you in the editor.
+
+### Ignore or collapse comments
+
+To remove a comment from the editor, click its **Ignore** icon.
+
+To remove a comment but keep an icon in the editor noting its presence, click its **Collapse** icon.
+
+To see an ignored or collapsed comment in the editor again, click its summary in the CodeRabbit sidebar.
+
+### Browse previous reviews
+
+If you have performed reviews prior to the most recent review in the current VSCode window, then you can browse the comments from these reviews under the **Previous reviews** heading in the CodeRabbit sidebar.
+
+If a past review comment no longer applies to the current state of your code, then clicking that comment won't display a detailed comment or suggestion in the editor.
+
 ## What's next
 
-- [Uninstall the VSCode extension](/guides/install-extension)
+- [Uninstall the VSCode extension](/guides/uninstall-vscode)

--- a/docs/guides/use-vscode.md
+++ b/docs/guides/use-vscode.md
@@ -1,0 +1,39 @@
+---
+title: Use the VSCode extension
+description: How to review your code with the VSCode extension.
+---
+
+This page is about using the CodeRabbit VSCode extension. For more information about the extension, see
+[Overview](/guides/about-vscode). To learn how to install the extension, see [Install the VSCode extension](/guides/install-vscode).
+
+## Review your code changes
+
+To manually review changes in a local Git branch using the CodeRabbit VSCode extension, follow these steps:
+
+1.  Click the CodeRabbit icon in the VSCode activity bar. The CodeRabbit sidebar appears.
+
+1.  Refer to **Branch** in the CodeRabbit sidebar. If you want to compare your code changes
+    to a branch other than the default that appears, then follow these steps:
+
+        1. Click the name of the base branch, which is `main` by default. A **Select a base branch** dialog appears, listing other branches in your local Git repository.
+
+        1. Select the name of a base branch to compare against.
+
+1.  Select one of the review-action options from the menu at the bottom of the CodeRabbit sidebar:
+
+    - To review all changes between the base branch and your current branch, including
+      both committed and uncommitted changes, select **Review all changes**. This is the default selection.
+
+    - To limit the review to only changes on your branch that you have committed, select **Review committed changes**. This includes both pushed and not-pushed commits on the current branch.
+
+    - To limit the review to only uncommitted changes on your branch, select **Review all changes**.
+
+1.  Refer to the list of **Files to review** in the sidebar. This list represents all of the files that the selected review style includes. To change this list of files, repeat the previous step to choose a different review style, or use Git features like `git stash` to remove changes to files.
+
+1.  To perform the review, click the button part of the menu. The CodeRabbit sidebar displays a **Review** section with the review's progress.
+
+1.  Wait for the review to complete. This might take several minutes. To cancel a review in progress, click **Stop the review**.
+
+## What's next
+
+- The CodeRabbit [Introduction](/overview/introduction) describes how you can complement the CodeRabbit VSCode extension by setting up automatic, full-featured code reviews on your remote repository's pull requests.

--- a/docs/guides/use-vscode.md
+++ b/docs/guides/use-vscode.md
@@ -22,7 +22,7 @@ To perform an automatic review, follow these steps:
 
 1. Click **Yes.** The CodeRabbit sidebar appears in your VSCode window.
 
-1. Wait for the review to complete. This might take several minutes. To cancel a review in progress, click **Stop the review**.
+1. Wait for the review to complete. This might take a few minutes. To cancel a review in progress, click **Stop the review**.
 
 After the review completes, you can browse and respond to review comments as described in [Work with code reviews](#work-with-code-reviews).
 
@@ -52,7 +52,7 @@ To manually review changes in a local Git branch using the CodeRabbit VSCode ext
 
 1. To perform the review, click the button part of the menu. The CodeRabbit sidebar displays a **Review** section with the review's progress.
 
-1. Wait for the review to complete. This might take several minutes. To cancel a review in progress, click **Stop the review**.
+1. Wait for the review to complete. This might take a few minutes. To cancel a review in progress, click **Stop the review**.
 
 After the review completes, you can browse and respond to review comments as described in the following section.
 

--- a/docs/guides/use-vscode.md
+++ b/docs/guides/use-vscode.md
@@ -8,6 +8,10 @@ This page is about performing local code reviews using the CodeRabbit VSCode ext
 
 The CodeRabbit VSCode extension works by comparing changes in your current, checked-out Git branch against another branch in your local repository. You can use the extension to automatically perform full-branch changes after every commit, or make different kinds of comparisons by manually requesting a review.
 
+:::note
+The instructions on this page are specific to using the extension with VSCode. If you are instead using a VSCode-compatible editor such as Cursor or Windsurf, then the steps that you need to follow are similar, but might require some adaptation.
+:::
+
 ## Automatically review local commits
 
 You can let CodeRabbit automatically review commits that you make to your local Git repository. These automatic reviews compare all committed changes against the branch that your working branch is based on.
@@ -28,29 +32,27 @@ For more options and control of code reviews performed using the CodeRabbit VSCo
 
 To manually review changes in a local Git branch using the CodeRabbit VSCode extension, follow these steps:
 
-1.  Click the CodeRabbit icon in the VSCode activity bar. The CodeRabbit sidebar appears.
+1. Click the CodeRabbit icon in the VSCode activity bar. The CodeRabbit sidebar appears.
 
-1.  If you want to compare your code changes
-    to a branch other than its base branch, then follow these steps:
+1. If you want to compare your code changes to a branch other than its base branch, then follow these steps:
 
-        1. In the sidebar, under **Branch**, click the name of the base branch. A **Select a base branch** dialog appears, listing other branches in your local Git repository.
+   1. In the sidebar, under **Branch**, click the name of the base branch. A **Select a base branch** dialog appears, listing other branches in your local Git repository.
 
-        1. Select the name of a base branch to compare against.
+   1. Select the name of a base branch to compare against.
 
-1.  Select one of the review-action options from the menu at the bottom of the CodeRabbit sidebar:
+1. Select one of the review-action options from the menu at the bottom of the CodeRabbit sidebar:
 
-    - To review all changes between the base branch and your current branch, including
-      both committed and uncommitted changes, select **Review all changes**. This is the default selection.
+   - To review all changes between the base branch and your current branch, including both committed and uncommitted changes, select **Review all changes**. This is the default selection.
 
-    - To limit the review to only changes on your branch that you have committed, select **Review committed changes**. This includes commits that you have pushed to your remote repository, if any, as well as any local commits.
+   - To limit the review to only changes on your branch that you have committed, select **Review committed changes**. This includes commits that you have pushed to your remote repository, if any, as well as any local commits.
 
-    - To limit the review to only uncommitted changes on your branch, select **Review uncommitted changes**.
+   - To limit the review to only uncommitted changes on your branch, select **Review uncommitted changes**. This includes both staged and unstaged changes.
 
-1.  Refer to the list of **Files to review** in the sidebar. This list represents all of the files that the selected review action includes. To change this list of files, repeat the previous step to choose a different review action, or use Git features like `git stash` to selectively remove changes.
+1. Refer to the list of **Files to review** in the sidebar. This list represents all of the files that the selected review action includes. To change this list of files, repeat the previous step to choose a different review action, or use Git features like `git stash` to selectively remove changes.
 
-1.  To perform the review, click the button part of the menu. The CodeRabbit sidebar displays a **Review** section with the review's progress.
+1. To perform the review, click the button part of the menu. The CodeRabbit sidebar displays a **Review** section with the review's progress.
 
-1.  Wait for the review to complete. This might take several minutes. To cancel a review in progress, click **Stop the review**.
+1. Wait for the review to complete. This might take several minutes. To cancel a review in progress, click **Stop the review**.
 
 After the review completes, you can browse and respond to review comments as described in the following section.
 

--- a/docs/guides/use-vscode.md
+++ b/docs/guides/use-vscode.md
@@ -6,7 +6,21 @@ description: How to review your code with the VSCode extension.
 This page is about using the CodeRabbit VSCode extension. For more information about the extension, see
 [Overview](/guides/about-vscode). To learn how to install the extension, see [Install the VSCode extension](/guides/install-vscode).
 
-## Review your code changes
+## Automatically review local commits
+
+You can let CodeRabbit automatically review commits that you make to your local Git repository. These automatic reviews compare all committed changes against the branch that your working branch is based on.
+
+To perform an automatic review, follow these steps:
+
+1. Perform a Git commit using VSCode. After you do this, a dialog appears in your VSCode window, asking **Would you like to start a review?**
+
+1. Click **Yes.** The CodeRabbit sidebar appears in your VSCode window.
+
+1. Wait for the review to complete. This might take several minutes. To cancel a review in progress, click **Stop the review**.
+
+For more options and control of code reviews performed using the CodeRabbit VSCode extension, you can manually request a review, as detailed in the following section.
+
+## Manually request code reviews
 
 To manually review changes in a local Git branch using the CodeRabbit VSCode extension, follow these steps:
 
@@ -36,4 +50,4 @@ To manually review changes in a local Git branch using the CodeRabbit VSCode ext
 
 ## What's next
 
-- The CodeRabbit [Introduction](/overview/introduction) describes how you can complement the CodeRabbit VSCode extension by setting up automatic, full-featured code reviews on your remote repository's pull requests.
+- [Uninstall the VSCode extension](/guides/install-extension)

--- a/docs/overview/introduction.md
+++ b/docs/overview/introduction.md
@@ -98,12 +98,12 @@ For private repositories, a number of pricing tiers are available. These range f
 
 As a separate, free product, CodeRabbit offers a VSCode extension that brings a subset of core CodeRabbit features to VSCode. This lets you use the power of CodeRabbit to tune and tidy your code changes locally before pushing your changes into a formal pull request for more thorough reviews.
 
-For more information, see [About the VSCode extension](/guides/about-vscode).
+For more information, see [Review local changes](/code-editors).
 
 ## What's next
 
 - [Quickstart](/getting-started/quickstart/) lets you experience your first CodeRabbit code review first-hand.
 
-- [About the VSCode extension] guides you through installing and using a subset of CodeRabbit features directly from your code editor.
+- [Review local changes](/code-editors) guides you through installing and using a subset of CodeRabbit features directly from your code editor.
 
 - [Why CodeRabbit?](/overview/why-coderabbit) dives further into the philosophies and technologies that drive CodeRabbit.

--- a/docs/overview/introduction.md
+++ b/docs/overview/introduction.md
@@ -94,8 +94,16 @@ Public repositories can use the Pro tier of CodeRabbit at no charge, including a
 
 For private repositories, a number of pricing tiers are available. These range from a Free tier that offers unlimited code-change summaries, to an Enterprise tier with access to advanced features and SLA support. For more information, see [Pricing](https://www.coderabbit.ai/pricing).
 
+## Review local changes from within VSCode
+
+As a separate, free product, CodeRabbit offers a VSCode extension that brings a subset of core CodeRabbit features to VSCode. This lets you use the power of CodeRabbit to tune and tidy your code changes locally before pushing your changes into a formal pull request for more thorough reviews.
+
+For more information, see [About the VSCode extension](/guides/about-vscode).
+
 ## What's next
 
 - [Quickstart](/getting-started/quickstart/) lets you experience your first CodeRabbit code review first-hand.
+
+- [About the VSCode extension] guides you through installing and using a subset of CodeRabbit features directly from your code editor.
 
 - [Why CodeRabbit?](/overview/why-coderabbit) dives further into the philosophies and technologies that drive CodeRabbit.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -111,7 +111,7 @@ const sidebars: SidebarsConfig = {
 		{
 			type: "category",
 			collapsed: false,
-			label: "Review local changes using the VSCode extension",
+			label: "Review local changes",
 			items: [
 				"guides/about-vscode",
 				"guides/install-vscode",

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -85,6 +85,8 @@ const sidebars: SidebarsConfig = {
 			label: "Review pull requests",
 			items: [
 				"guides/commands",
+				"guides/code-review-best-practices",
+				"guides/code-review-troubleshooting",
 				"guides/agent_chat",
 				{
 					type: "category",
@@ -111,6 +113,17 @@ const sidebars: SidebarsConfig = {
 		{
 			type: "category",
 			collapsed: false,
+			label: "Review local changes using the VSCode extension",
+			items: [
+				"guides/about-vscode",
+				"guides/install-vscode",
+				"guides/use-vscode",
+				"guides/uninstall-vscode",
+			],
+		},
+		{
+			type: "category",
+			collapsed: false,
 			label: "Generate reports",
 			items: [
 				"guides/ondemand-reports",
@@ -128,6 +141,7 @@ const sidebars: SidebarsConfig = {
 					label: "CodeRabbit API",
 					href: "https://api.coderabbit.ai/api/swagger/",
 				},
+				"reference/review-commands",
 				{
 					type: "category",
 					label: "Supported tools",

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -85,8 +85,6 @@ const sidebars: SidebarsConfig = {
 			label: "Review pull requests",
 			items: [
 				"guides/commands",
-				"guides/code-review-best-practices",
-				"guides/code-review-troubleshooting",
 				"guides/agent_chat",
 				{
 					type: "category",
@@ -141,7 +139,6 @@ const sidebars: SidebarsConfig = {
 					label: "CodeRabbit API",
 					href: "https://api.coderabbit.ai/api/swagger/",
 				},
-				"reference/review-commands",
 				{
 					type: "category",
 					label: "Supported tools",


### PR DESCRIPTION
Fixes #329 Fixes #330 Fixes #327 Fixes #328 Fixes #321

Staged:

* New docs pages start here: https://use-vscode.coderabbit-docs.pages.dev/code-editors
* New section added to the CodeRabbit intro page: https://use-vscode.coderabbit-docs.pages.dev/#review-local-changes-from-within-vscode