### PR TITLE
Default ToC menus to collapsed rather than expanded.

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -30,13 +30,13 @@ const sidebars: SidebarsConfig = {
 	docsSidebar: [
 		{
 			type: "category",
-			collapsed: false,
+			collapsed: true,
 			label: "Get started with CodeRabbit",
 			items: ["overview/introduction", "getting-started/quickstart"],
 		},
 		{
 			type: "category",
-			collapsed: false,
+			collapsed: true,
 			label: "Add CodeRabbit to your repository",
 			items: [
 				"platforms/platforms",
@@ -70,7 +70,7 @@ const sidebars: SidebarsConfig = {
 		},
 		{
 			type: "category",
-			collapsed: false,
+			collapsed: true,
 			label: "Configure CodeRabbit",
 			items: [
 				"getting-started/configure-coderabbit",
@@ -81,14 +81,14 @@ const sidebars: SidebarsConfig = {
 		},
 		{
 			type: "category",
-			collapsed: false,
+			collapsed: true,
 			label: "Review pull requests",
 			items: [
 				"guides/commands",
 				"guides/agent_chat",
 				{
 					type: "category",
-					collapsed: false,
+					collapsed: true,
 					label: "Analyze and improve your code",
 					items: [
 						"integrations/code-graph-analysis",
@@ -99,7 +99,7 @@ const sidebars: SidebarsConfig = {
 		},
 		{
 			type: "category",
-			collapsed: false,
+			collapsed: true,
 			label: "Create and resolve issues",
 			items: [
 				"integrations/issue-integrations",
@@ -110,7 +110,7 @@ const sidebars: SidebarsConfig = {
 		},
 		{
 			type: "category",
-			collapsed: false,
+			collapsed: true,
 			label: "Review local changes",
 			items: [
 				"guides/about-vscode",
@@ -122,7 +122,7 @@ const sidebars: SidebarsConfig = {
 		},
 		{
 			type: "category",
-			collapsed: false,
+			collapsed: true,
 			label: "Generate reports",
 			items: [
 				"guides/ondemand-reports",
@@ -132,7 +132,7 @@ const sidebars: SidebarsConfig = {
 		},
 		{
 			type: "category",
-			collapsed: false,
+			collapsed: true,
 			label: "Reference",
 			items: [
 				{
@@ -177,7 +177,7 @@ const sidebars: SidebarsConfig = {
 		},
 		{
 			type: "category",
-			collapsed: false,
+			collapsed: true,
 			label: "Resources",
 			items: [
 				"getting-started/support",


### PR DESCRIPTION
Staged: https://collapse-toc.coderabbit-docs.pages.dev/

Now that we've reorganized the table of contents so that top-level tiers align with the major features of CodeRabbit—expressed as the tasks that you can accomplish with it—I recommend that we have the ToC begin a session collapsed by default, as demonstrated at the staged link above, instead of almost fully expanded the way it is now.

This is much visually cleaner, and puts far less cognitive load on the reader. They can find the major topic they're interested in at a glance and begin exploring it with a click, instead of having to scan a list of pages and topics that stretches far longer than a single screen.

Furthermore, I was honestly finding the current style pretty unwieldy to work with as a content author, let alone a reader! 

Fixes #343 