### PR TITLE
Add Pylint Documentation to Tools Section

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,7 +20,6 @@ Here's why you'll love it:
 
 For more details, please visit our [tools documentation](https://docs.coderabbit.ai/tools/pylint).
 
-
 ## May 25, 2025
 
 ### New Security and Code Quality Tools

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,22 @@ sidebar_label: Changelog
 description: The latest updates and changes to CodeRabbit.
 sidebar_position: 13
 ---
+### May 30, 2025
+
+#### New Static Analysis Tool
+
+We're excited to announce that [Pylint](https://github.com/PyCQA/pylint) is now supported on CodeRabbit!
+
+- **Pylint**: A widely used static analysis and code quality tool for Python. It checks for errors, enforces a coding standard, and looks for code smells in your Python codebase by analyzing Python files (`.py`).
+
+Here's why you'll love it:
+
+- 🐞 **Instantly catches bugs** and style issues in your Python code.  
+- 🪄 **Enforces clean, consistent code** across your entire team.  
+- 🧩 **Fully customizable** to match your project's unique coding standards.
+
+For more details, please visit our [tools documentation](https://docs.coderabbit.ai/tools/pylint).
+
 
 ## May 25, 2025
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@ sidebar_label: Changelog
 description: The latest updates and changes to CodeRabbit.
 sidebar_position: 13
 ---
+
 ### May 30, 2025
 
 #### New Static Analysis Tool
@@ -14,8 +15,8 @@ We're excited to announce that [Pylint](https://github.com/PyCQA/pylint) is now 
 
 Here's why you'll love it:
 
-- 🐞 **Instantly catches bugs** and style issues in your Python code.  
-- 🪄 **Enforces clean, consistent code** across your entire team.  
+- 🐞 **Instantly catches bugs** and style issues in your Python code.
+- 🪄 **Enforces clean, consistent code** across your entire team.
 - 🧩 **Fully customizable** to match your project's unique coding standards.
 
 For more details, please visit our [tools documentation](https://docs.coderabbit.ai/tools/pylint).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,15 +11,7 @@ sidebar_position: 13
 
 We're excited to announce that [Pylint](https://github.com/PyCQA/pylint) is now supported on CodeRabbit!
 
-- **Pylint**: A widely used static analysis and code quality tool for Python. It checks for errors, enforces a coding standard, and looks for code smells in your Python codebase by analyzing Python files (`.py`).
-
-Here's why you'll love it:
-
-- 🐞 **Instantly catches bugs** and style issues in your Python code.
-- 🪄 **Enforces clean, consistent code** across your entire team.
-- 🧩 **Fully customizable** to match your project's unique coding standards.
-
-For more details, please visit our [tools documentation](https://docs.coderabbit.ai/tools/pylint).
+- **Pylint**: A widely used static analysis and code quality tool for Python. It checks for errors, enforces a coding standard, and looks for code smells in your Python codebase by analyzing Python files.
 
 ## May 25, 2025
 

--- a/docs/tools/list.md
+++ b/docs/tools/list.md
@@ -33,7 +33,7 @@ For an overview of how CodeRabbit uses these tools when generating code reviews,
 | Plaintext                   | [LanguageTool][LanguageTool]                               | Grammar and Spell Checking                          |
 | Java                        | [PMD][PMD]                                                 | Code Quality                                        |
 | Protobuf                    | [Buf][Buf]                                                 | Code Quality                                        |
-| Python                      | [Ruff][Ruff]                                               | Code Quality                                        |
+| Python                      | [Ruff][Ruff], [Pylint][Pylint]                             | Code Quality                                        |
 | Regal                       | [Regal][Regal]                                             | Code Quality                                        |
 | Ruby                        | [RuboCop][RuboCop], [Brakeman][Brakeman]                   | Code Quality, Code Security                         |
 | Rust                        | [Clippy][Clippy]                                           | Code Quality                                        |
@@ -77,3 +77,4 @@ For an overview of how CodeRabbit uses these tools when generating code reviews,
 [Luacheck]: /tools/luacheck.md
 [Brakeman]: /tools/brakeman.md
 [Clippy]: /tools/clippy.md
+[Pylint]: /tools/pylint.md

--- a/docs/tools/pylint.md
+++ b/docs/tools/pylint.md
@@ -1,0 +1,37 @@
+---
+title: Pylint
+sidebar_label: Pylint
+description: CodeRabbit's guide to Pylint.
+---
+
+```mdx-code-block
+import ProPlanNotice from '@site/src/components/ProPlanNotice.mdx';
+
+<ProPlanNotice />
+```
+
+[Pylint](https://pylint.pycqa.org/) is a static code analysis tool for Python. It checks your Python code for errors, enforces a coding standard, and looks for code smells.
+
+## Supported Files
+
+Pylint will run on files with the following extensions:
+
+- `*.py`
+
+## Features
+
+Pylint can detect many issues such as:
+
+- Coding standard violations (PEP8)
+- Unused variables and imports
+- Undefined variables
+- Code smells and refactoring suggestions
+- Error-prone constructs
+- And many more
+
+## Links
+
+- [Pylint Official Website](https://pylint.pycqa.org/)
+- [Pylint GitHub Repository](https://github.com/pylint-dev/pylint)
+- [Pylint Documentation](https://pylint.pycqa.org/en/latest/)
+- [Message Control](https://pylint.pycqa.org/en/latest/user_guide/message-control.html)


### PR DESCRIPTION
- Added a new `pylint.md` page under `docs/tools/` with usage instructions and links.
- Included a changelog entry announcing Pylint support on May 30, 2025.
- Updated `docs/tools/list.md` to include Pylint in the supported tools list.
