### PR TITLE
Add a step about 2FA to the Bitbucket instructions.

### DIFF
--- a/docs/platforms/bitbucket-cloud.md
+++ b/docs/platforms/bitbucket-cloud.md
@@ -18,8 +18,9 @@ This guide will assist you in effectively integrating CodeRabbit with Bitbucket 
 To enable CodeRabbit to interact with your Bitbucket repositories, an app password is required. This token grants the necessary permissions for interacting with the Merge Requests and Discussions APIs.
 
 1. Create a new Bitbucket account specifically for CodeRabbit and treat it as a service account.
-2. Name the account "CodeRabbit".
-3. Generate an App Password to enable seamless integration between CodeRabbit and your Bitbucket repositories.
+1. Name the account "CodeRabbit".
+1. If your Bitbucket workspace requires two-step verification, then you must also enable two-step verification on this new account.
+1. Generate an App Password to enable seamless integration between CodeRabbit and your Bitbucket repositories.
 
 We recommend creating a new user as a service account, associating this user to the workspace you'd like to install CodeRabbit on, and providing CodeRabbit with the app password to allow access. During the installation process, CodeRabbit will automatically configure the required webhook for seamless integration.
 


### PR DESCRIPTION
Fixes #347 

Staged: https://bitbucket.coderabbit-docs.pages.dev/platforms/bitbucket-cloud#configure-app-password