### PR TITLE
Hide the auto-generated next/prev links.

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -293,3 +293,8 @@ a[docid="docs"] > svg {
 		display: none;
 	}
 }
+
+/* Disable automatic next/previous pagination links */
+.pagination-nav {
+	display: none;
+}


### PR DESCRIPTION
Staged: https://next-prev.coderabbit-docs.pages.dev/ (And all pages therein)

This change hides the "naive" auto-generated next/previous links at the bottom of every page, which we decided to remove as part of our springtime information architecture revisions.

Fixes #316 