### PR TITLE
Add estimate_code_review_effort to yaml-template.md

### DIFF
--- a/docs/reference/yaml-template.md
+++ b/docs/reference/yaml-template.md
@@ -31,6 +31,7 @@ reviews:
   collapse_walkthrough: false
   changed_files_summary: true
   sequence_diagrams: true
+  estimate_code_review_effort: true
   assess_linked_issues: true
   related_issues: true
   related_prs: true


### PR DESCRIPTION
- This adds missing `estimate_code_review_effort` to the YAML template reference. 
- [Schema](https://github.com/coderabbitai/coderabbit-docs/blob/ee5a787fde59b4f196bd268a14d4af54cb706dfe/static/schema/schema.v2.json#L198) exposes this attribute

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the configuration template documentation to include a new option, `estimate_code_review_effort`, under the `reviews` section. This option is enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->